### PR TITLE
Fix: Balls keep their colours even when new balls are spawned

### DIFF
--- a/scenes/game.lua
+++ b/scenes/game.lua
@@ -142,39 +142,36 @@ function game.update(dt)
 		-- *but* you should be able to drag it out outside of the boundary.
 		local bndry = lvl.throwBoundary
 		local withinBoundary = checkCollision(mx,my,5,5, bndry.x, bndry.y, bndry.w, bndry.h)
-		if (withinBoundary and not oldmousedown) or grabbedBall then
+		if withinBoundary and not oldmousedown and not grabbedBall then
 			-- Just started holding the mouse? Create a ball at the mouse's position,
 			-- add a mouse joint to keep it static until thrown.
-			if not grabbedBall then
-				sound.play("spawn")
+			sound.play("spawn")
 
-				local ball = world:newCollider("Circle", {mx, my, 30})
-				-- Set the thrown object to a "bullet", which uses more detailed collision detection
-				-- to prevent it jumping over bodies if the velocity is high enough
-				ball:setBullet(true)
+			local ball = world:newCollider("Circle", {mx, my, 30})
+			-- Set the thrown object to a "bullet", which uses more detailed collision detection
+			-- to prevent it jumping over bodies if the velocity is high enough
+			ball:setBullet(true)
 
-				ball.colour = coolRandomColour()
-				ball.debug_step = 0
+			ball.colour = coolRandomColour()
+			ball.debug_step = 0
 
-				function ball:draw()
-					draw.ball(self:getX(), self:getY(), self:getAngle(), ball.colour)
-				end
-
-				joints.boxMouse = love.physics.newMouseJoint(ball.body, mx, my)
-				joints.boxMouse:setTarget(mx, my)
-
-				-- We now have a ball grabbed, don't boundary check anymore.
-				grabbedBall = ball
+			function ball:draw()
+				draw.ball(self:getX(), self:getY(), self:getAngle(), ball.colour)
 			end
 
-			if grabbedBall then
-				-- Now we're holding it down...
-				-- Calculate "throw vector", like a slingshot. It is inverse of the vector
-				-- that is the difference in coordinates between the created ball and mouse.
-				local ox, oy = grabbedBall:getPosition()
-				throw.x = -(mx-ox)
-				throw.y = -(my-oy)
-			end
+			joints.boxMouse = love.physics.newMouseJoint(ball.body, mx, my)
+			joints.boxMouse:setTarget(mx, my)
+
+			-- We now have a ball grabbed, don't boundary check anymore.
+			grabbedBall = ball
+		end
+		if grabbedBall then
+			-- Now we're holding it down...
+			-- Calculate "throw vector", like a slingshot. It is inverse of the vector
+			-- that is the difference in coordinates between the created ball and mouse.
+			local ox, oy = grabbedBall:getPosition()
+			throw.x = -(mx-ox)
+			throw.y = -(my-oy)
 		end
 
 	-- When grabbedBall is defined, but mouse is not held (i.e. mouse has been released, we're throwing it!)


### PR DESCRIPTION
## Problem description

Previously, when a level allowed for multiple balls (like e.g. Level 1), spawning a new ball would change the colour of all previous balls.

This would happen, because the colour of the ball(s) was defined by `ball.colour`. The problem with that was, that `ball` was a local variable scoped to the whole level scene. While the physics properties remained properly scoped, the same `ball.colour` got overwritten on spawning a new ball.

## Solution

I have moved `ball` from being scoped to the scene down to being scoped to the if-clause it is created in.
To still allow access to the ball outside this context (for e.g. drawing the throw vector and applying force) I have repurposed the `grabbedBall` variable. Instead of being a `bool` it is now a reference to the currently grabbed ball.

While I was at it, I also removed the `helddown` variable, as its purpose was the same as `grabbedBall`.

Finally, I refactored the if clause around this whole logic. Previously it was a bit confusing as it read:
```lua
if (withinBoundary and not oldmousedown) or grabbedBall then
  if not helddown then
     -- since helddown and grabbedBall mean the same thing, this is equivalent to:
     -- if ((withinBoundary and not oldmousedown) or (grabbedBall)) and not grabbedBall
     -- which can only be true for grabbedBall == false
  end
  if ball then
    -- this one draws the throw vector, so we mostly were checking for grabbedBall (and ball, just to be sure that we can get its position)
    -- but we're still in the confusingly big if-clause, making it really confusing
  end
```

Now we have:

```lua
if withinBoundary and not oldmousedown and not grabbedBall then
 -- still a lot, but clear what we want to do
end
if grabbedBall then
  -- since grabbedBall is a reference, we can be sure that it has a position
  -- and it only exists while we're aiming, which is the time we want to draw the throw vector
end
```